### PR TITLE
fix(metrics): use global registry

### DIFF
--- a/test/framework/report.go
+++ b/test/framework/report.go
@@ -10,14 +10,15 @@ import (
 
 const prometheusPushgatewayApp = "prometheus-pushgateway"
 
-func testStatusGauge(spec string) prometheus.Gauge {
-	return prometheus.NewGauge(prometheus.GaugeOpts{
+var registry = prometheus.NewRegistry()
+var testStatusStarted *prometheus.GaugeVec
+
+func init() {
+	testStatusStarted = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "test_status",
 		Help: "If value is '1' then the test is in progress, if '0' then the test ended",
-		ConstLabels: map[string]string{
-			"spec_name": spec,
-		},
-	})
+	}, []string{"spec"})
+	registry.MustRegister(testStatusStarted)
 }
 
 func ReportSpecStart(cluster *framework.K8sCluster) error {
@@ -31,10 +32,7 @@ func ReportSpecEnd(cluster *framework.K8sCluster) error {
 }
 
 func push(endpoint string, value float64) error {
-	registry := prometheus.NewRegistry()
-	g := testStatusGauge(ginkgo.CurrentSpecReport().FullText())
-	registry.MustRegister(g)
-	g.Set(value)
+	testStatusStarted.WithLabelValues(ginkgo.CurrentSpecReport().FullText()).Set(value)
 	return prometheus_push.New(endpoint, "mesh_perf_test").Gatherer(registry).Push()
 }
 


### PR DESCRIPTION
It used to work because I actively queried Prometheus while testing this. 