### PR TITLE
feat: add stabilization sleep

### DIFF
--- a/.github/workflows/perf-test-eks.yaml
+++ b/.github/workflows/perf-test-eks.yaml
@@ -35,7 +35,7 @@ jobs:
       - name: Configure kubectl
         run: aws eks --region us-west-1 update-kubeconfig --name mesh-perf
       - name: Run tests
-        run: MESH_VERSION=${{ inputs.mesh_version }} make run
+        run: MESH_VERSION=${{ inputs.mesh_version }} STABILIZATION_SLEEP=30s make run
       - uses: actions/upload-artifact@v3
         with:
           name: test-metrics-snapshot

--- a/test/k8s/simple_test.go
+++ b/test/k8s/simple_test.go
@@ -57,6 +57,7 @@ data:
 	})
 
 	AfterEach(func() {
+		time.Sleep(stabilizationSleep)
 		Expect(ReportSpecEnd(cluster)).To(Succeed())
 	})
 

--- a/test/k8s/suite_test.go
+++ b/test/k8s/suite_test.go
@@ -3,6 +3,7 @@ package k8s_test
 import (
 	"os"
 	"testing"
+	"time"
 
 	"github.com/kumahq/kuma/pkg/test"
 	. "github.com/kumahq/kuma/test/framework"
@@ -18,6 +19,7 @@ func TestE2E(t *testing.T) {
 }
 
 var cluster *K8sCluster
+var stabilizationSleep = 10 * time.Second
 
 const obsNamespace = "mesh-observability"
 
@@ -25,6 +27,14 @@ var _ = BeforeSuite(func() {
 	kubeConfigPath := os.Getenv("KUBECONFIG")
 	if kubeConfigPath == "" {
 		kubeConfigPath = "${HOME}/.kube/config"
+	}
+
+	if sleep := os.Getenv("STABILIZATION_SLEEP"); sleep != "" {
+		sleepDur, err := time.ParseDuration(sleep)
+		if err != nil {
+			panic(err)
+		}
+		stabilizationSleep = sleepDur
 	}
 
 	cluster = NewK8sCluster(NewTestingT(), "mesh-perf", true)


### PR DESCRIPTION
Add stabilization sleep to a test so we can track what is the perf of the CP after the given test scenario is executed. This also lets us track that we don't do any unnecessary reconciliations after all the changes to the environment are done.

Fix #33