### PR TITLE
feat(grafana): new panels using Grafonnet for 'perf-test' dashboard

### DIFF
--- a/jsonnetfile.lock.json
+++ b/jsonnetfile.lock.json
@@ -58,7 +58,7 @@
           "subdir": "jsonnet/v10.0.0"
         }
       },
-      "version": "8a4d53df8dc53b005a22125bc199366787dd271a",
+      "version": "7a7f6b80de0ba5713a7ed45833acf5f641b08d4d",
       "sum": "cpxEEjeaQMUYA938vuVie3s5SSRv+O9IWwL9F1m44Qk="
     },
     {

--- a/tools/observability/grafana/provisioning/dashboards/perf-test.json
+++ b/tools/observability/grafana/provisioning/dashboards/perf-test.json
@@ -83,8 +83,8 @@
                   "type": "prometheus",
                   "uid": "Prometheus"
                },
-               "expr": "histogram_quantile(0.99, sum(rate(apiserver_request_duration_seconds_bucket{group=\"kuma.io\"}[$__rate_interval])) by (le))",
-               "legendFormat": "0.99"
+               "expr": "histogram_quantile(0.50, sum(rate(apiserver_request_duration_seconds_bucket{group=\"kuma.io\"}[$__rate_interval])) by (le))",
+               "legendFormat": "0.50"
             },
             {
                "datasource": {
@@ -99,8 +99,8 @@
                   "type": "prometheus",
                   "uid": "Prometheus"
                },
-               "expr": "histogram_quantile(0.50, sum(rate(apiserver_request_duration_seconds_bucket{group=\"kuma.io\"}[$__rate_interval])) by (le))",
-               "legendFormat": "0.50"
+               "expr": "histogram_quantile(0.99, sum(rate(apiserver_request_duration_seconds_bucket{group=\"kuma.io\"}[$__rate_interval])) by (le))",
+               "legendFormat": "0.99"
             }
          ],
          "title": "Latency of Kube API server responses",
@@ -205,8 +205,8 @@
                   "type": "prometheus",
                   "uid": "Prometheus"
                },
-               "expr": "histogram_quantile(0.99, sum(rate(store_bucket[$__rate_interval])) by (le))",
-               "legendFormat": "0.99"
+               "expr": "histogram_quantile(0.50, sum(rate(store_bucket[$__rate_interval])) by (le))",
+               "legendFormat": "0.50"
             },
             {
                "datasource": {
@@ -221,8 +221,8 @@
                   "type": "prometheus",
                   "uid": "Prometheus"
                },
-               "expr": "histogram_quantile(0.50, sum(rate(store_bucket[$__rate_interval])) by (le))",
-               "legendFormat": "0.50"
+               "expr": "histogram_quantile(0.99, sum(rate(store_bucket[$__rate_interval])) by (le))",
+               "legendFormat": "0.99"
             }
          ],
          "title": "Latency of store operations",
@@ -252,8 +252,8 @@
                   "type": "prometheus",
                   "uid": "Prometheus"
                },
-               "expr": "histogram_quantile(0.99, sum(rate(api_server_http_request_duration_seconds_bucket[$__rate_interval])) by (le))",
-               "legendFormat": "0.99"
+               "expr": "histogram_quantile(0.50, sum(rate(api_server_http_request_duration_seconds_bucket[$__rate_interval])) by (le))",
+               "legendFormat": "0.50"
             },
             {
                "datasource": {
@@ -268,8 +268,8 @@
                   "type": "prometheus",
                   "uid": "Prometheus"
                },
-               "expr": "histogram_quantile(0.50, sum(rate(api_server_http_request_duration_seconds_bucket[$__rate_interval])) by (le))",
-               "legendFormat": "0.50"
+               "expr": "histogram_quantile(0.99, sum(rate(api_server_http_request_duration_seconds_bucket[$__rate_interval])) by (le))",
+               "legendFormat": "0.99"
             }
          ],
          "title": "Latency of Kuma API server responses",

--- a/tools/observability/grafana/provisioning/dashboards/perf-test.json
+++ b/tools/observability/grafana/provisioning/dashboards/perf-test.json
@@ -58,6 +58,356 @@
          ],
          "title": "Pod Startup Time",
          "type": "timeseries"
+      },
+      {
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "description": "The latency between a request sent from a client and a response returned by kube-apiserver",
+         "fieldConfig": {
+            "defaults": {
+               "unit": "s"
+            }
+         },
+         "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 8,
+            "y": 1
+         },
+         "id": 3,
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "Prometheus"
+               },
+               "expr": "histogram_quantile(0.99, sum(rate(apiserver_request_duration_seconds_bucket{group=\"kuma.io\"}[$__rate_interval])) by (le))",
+               "legendFormat": "0.99"
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "Prometheus"
+               },
+               "expr": "histogram_quantile(0.90, sum(rate(apiserver_request_duration_seconds_bucket{group=\"kuma.io\"}[$__rate_interval])) by (le))",
+               "legendFormat": "0.90"
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "Prometheus"
+               },
+               "expr": "histogram_quantile(0.50, sum(rate(apiserver_request_duration_seconds_bucket{group=\"kuma.io\"}[$__rate_interval])) by (le))",
+               "legendFormat": "0.50"
+            }
+         ],
+         "title": "Latency of Kube API server responses",
+         "type": "timeseries"
+      },
+      {
+         "collapsed": false,
+         "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 9
+         },
+         "id": 4,
+         "panels": [ ],
+         "title": "Kuma Control Plane",
+         "type": "row"
+      },
+      {
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "description": "Time between setting the config into snapshot up to receiving ACK/NACK",
+         "fieldConfig": {
+            "defaults": {
+               "unit": "ms"
+            }
+         },
+         "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 0,
+            "y": 10
+         },
+         "id": 5,
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "Prometheus"
+               },
+               "expr": "xds_delivery",
+               "legendFormat": "{{quantile}}"
+            }
+         ],
+         "title": "Latency of XDS config delivery",
+         "type": "timeseries"
+      },
+      {
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "description": "Time spent on generating XDS config",
+         "fieldConfig": {
+            "defaults": {
+               "unit": "ms"
+            }
+         },
+         "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 8,
+            "y": 10
+         },
+         "id": 6,
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "Prometheus"
+               },
+               "expr": "xds_generation{result=\"changed\"}",
+               "legendFormat": "{{quantile}}"
+            }
+         ],
+         "title": "Latency of XDS config generation",
+         "type": "timeseries"
+      },
+      {
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "description": "The latency between a request sent from a Kuma CP and a response returned by store",
+         "fieldConfig": {
+            "defaults": {
+               "unit": "s"
+            }
+         },
+         "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 16,
+            "y": 10
+         },
+         "id": 7,
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "Prometheus"
+               },
+               "expr": "histogram_quantile(0.99, sum(rate(store_bucket[$__rate_interval])) by (le))",
+               "legendFormat": "0.99"
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "Prometheus"
+               },
+               "expr": "histogram_quantile(0.90, sum(rate(store_bucket[$__rate_interval])) by (le))",
+               "legendFormat": "0.90"
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "Prometheus"
+               },
+               "expr": "histogram_quantile(0.50, sum(rate(store_bucket[$__rate_interval])) by (le))",
+               "legendFormat": "0.50"
+            }
+         ],
+         "title": "Latency of store operations",
+         "type": "timeseries"
+      },
+      {
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "description": "The latency between a request sent from a client and a response returned by Kuma API Server",
+         "fieldConfig": {
+            "defaults": {
+               "unit": "s"
+            }
+         },
+         "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 0,
+            "y": 19
+         },
+         "id": 8,
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "Prometheus"
+               },
+               "expr": "histogram_quantile(0.99, sum(rate(api_server_http_request_duration_seconds_bucket[$__rate_interval])) by (le))",
+               "legendFormat": "0.99"
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "Prometheus"
+               },
+               "expr": "histogram_quantile(0.90, sum(rate(api_server_http_request_duration_seconds_bucket[$__rate_interval])) by (le))",
+               "legendFormat": "0.90"
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "Prometheus"
+               },
+               "expr": "histogram_quantile(0.50, sum(rate(api_server_http_request_duration_seconds_bucket[$__rate_interval])) by (le))",
+               "legendFormat": "0.50"
+            }
+         ],
+         "title": "Latency of Kuma API server responses",
+         "type": "timeseries"
+      },
+      {
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "description": "Number of snapshot reconciliations both when config changed and skipped",
+         "fieldConfig": {
+            "defaults": {
+               "unit": "ops"
+            }
+         },
+         "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 8,
+            "y": 19
+         },
+         "id": 9,
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "Prometheus"
+               },
+               "expr": "rate(xds_generation_count[$__rate_interval])",
+               "legendFormat": "{{result}}"
+            }
+         ],
+         "title": "Number of XDS reconciliations",
+         "type": "timeseries"
+      },
+      {
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "description": "Number of requests Kuma CP is producing against the store",
+         "fieldConfig": {
+            "defaults": {
+               "unit": "ops"
+            }
+         },
+         "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 16,
+            "y": 19
+         },
+         "id": 10,
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "Prometheus"
+               },
+               "expr": "sum by (operation) (rate(store_count[$__rate_interval]))",
+               "legendFormat": "{{operation}}"
+            }
+         ],
+         "title": "Number of store operations",
+         "type": "timeseries"
+      },
+      {
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "description": "Cache protects ClusterLoadAssignments resources by sharing them between many goroutines which reconcile Dataplanes.\n\nhit - request was retrieved from the cache.\n\nhit-wait - request was retrieved from the cache after waiting for a concurrent request to fetch it from the database.\n\nmiss - request was fetched from the database\n\nRefer to https://kuma.io/docs/latest/documentation/fine-tuning/#snapshot-generation\n",
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 25,
+                  "stacking": {
+                     "mode": "percent"
+                  }
+               }
+            }
+         },
+         "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 0,
+            "y": 28
+         },
+         "id": 11,
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "Prometheus"
+               },
+               "expr": "sum by (result) (rate(cla_cache[$__rate_interval]))",
+               "legendFormat": "{{result}}"
+            }
+         ],
+         "title": "Endpoints cache performance",
+         "type": "timeseries"
+      },
+      {
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "description": "Mesh Cache protects hashes calculated periodically for each Mesh in order to avoid the excessive generation of xDS resources.\n\nhit - request was retrieved from the cache.\n\nhit-wait - request was retrieved from the cache after waiting for a concurrent request to fetch it from the database.\n\nmiss - request was fetched from the database\n\nRefer to https://kuma.io/docs/latest/documentation/fine-tuning/#snapshot-generation\n",
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 25,
+                  "stacking": {
+                     "mode": "percent"
+                  }
+               }
+            }
+         },
+         "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 8,
+            "y": 28
+         },
+         "id": 12,
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "Prometheus"
+               },
+               "expr": "sum by (result) (rate(mesh_cache[$__rate_interval]))",
+               "legendFormat": "{{result}}"
+            }
+         ],
+         "title": "Mesh resources hash cache performance",
+         "type": "timeseries"
       }
    ],
    "schemaVersion": 36,

--- a/tools/observability/grafana/provisioning/dashboards/perf-test/main.libsonnet
+++ b/tools/observability/grafana/provisioning/dashboards/perf-test/main.libsonnet
@@ -31,9 +31,9 @@ g.dashboard.new('Perf Test')
       'Latency of Kube API server responses', 
       'The latency between a request sent from a client and a response returned by kube-apiserver', 
       [
-        queries.kubeApiServerRequestLatency(ds.uid, "0.99"),
+        queries.kubeApiServerRequestLatency(ds.uid, "0.50"),
         queries.kubeApiServerRequestLatency(ds.uid, "0.90"),
-        queries.kubeApiServerRequestLatency(ds.uid, "0.50")
+        queries.kubeApiServerRequestLatency(ds.uid, "0.99"),
       ]),
   ]),
   
@@ -51,17 +51,17 @@ g.dashboard.new('Perf Test')
       'Latency of store operations',
       'The latency between a request sent from a Kuma CP and a response returned by store',
       [
-        queries.kumaStoreRequestLatency(ds.uid, "0.99"),
-        queries.kumaStoreRequestLatency(ds.uid, "0.90"),
         queries.kumaStoreRequestLatency(ds.uid, "0.50"),
+        queries.kumaStoreRequestLatency(ds.uid, "0.90"),
+        queries.kumaStoreRequestLatency(ds.uid, "0.99"),
       ]),
     panels.seconds(
       'Latency of Kuma API server responses',
       'The latency between a request sent from a client and a response returned by Kuma API Server',
       [
-        queries.kumaApiServerLatency(ds.uid, "0.99"),
-        queries.kumaApiServerLatency(ds.uid, "0.90"),
         queries.kumaApiServerLatency(ds.uid, "0.50"),
+        queries.kumaApiServerLatency(ds.uid, "0.90"),
+        queries.kumaApiServerLatency(ds.uid, "0.99"),
       ]),
     panels.opsPerSec(
       'Number of XDS reconciliations',

--- a/tools/observability/grafana/provisioning/dashboards/perf-test/main.libsonnet
+++ b/tools/observability/grafana/provisioning/dashboards/perf-test/main.libsonnet
@@ -20,8 +20,85 @@ g.dashboard.new('Perf Test')
   ])
 
 + g.dashboard.withPanels(g.util.grid.makeGrid([
+
   row.new('Kubernetes')
   + row.withPanels([
-    panels.milliseconds('Pod Startup Time', 'Average time between Pod creation and readiness', queries.avgPodTimeToStart(ds.uid))
+    panels.milliseconds(
+      'Pod Startup Time', 
+      'Average time between Pod creation and readiness', 
+      queries.avgPodTimeToStart(ds.uid)),
+    panels.seconds(
+      'Latency of Kube API server responses', 
+      'The latency between a request sent from a client and a response returned by kube-apiserver', 
+      [
+        queries.kubeApiServerRequestLatency(ds.uid, "0.99"),
+        queries.kubeApiServerRequestLatency(ds.uid, "0.90"),
+        queries.kubeApiServerRequestLatency(ds.uid, "0.50")
+      ]),
+  ]),
+  
+  row.new('Kuma Control Plane')
+  + row.withPanels([
+    panels.milliseconds(
+      'Latency of XDS config delivery', 
+      'Time between setting the config into snapshot up to receiving ACK/NACK',
+      queries.xdsDelivery(ds.uid)),
+    panels.milliseconds(
+      'Latency of XDS config generation', 
+      'Time spent on generating XDS config',
+      queries.xdsGeneration(ds.uid)),
+    panels.seconds(
+      'Latency of store operations',
+      'The latency between a request sent from a Kuma CP and a response returned by store',
+      [
+        queries.kumaStoreRequestLatency(ds.uid, "0.99"),
+        queries.kumaStoreRequestLatency(ds.uid, "0.90"),
+        queries.kumaStoreRequestLatency(ds.uid, "0.50"),
+      ]),
+    panels.seconds(
+      'Latency of Kuma API server responses',
+      'The latency between a request sent from a client and a response returned by Kuma API Server',
+      [
+        queries.kumaApiServerLatency(ds.uid, "0.99"),
+        queries.kumaApiServerLatency(ds.uid, "0.90"),
+        queries.kumaApiServerLatency(ds.uid, "0.50"),
+      ]),
+    panels.opsPerSec(
+      'Number of XDS reconciliations',
+      'Number of snapshot reconciliations both when config changed and skipped',
+      queries.xdsGenerationRate(ds.uid)),
+    panels.opsPerSec(
+      'Number of store operations',
+      'Number of requests Kuma CP is producing against the store',
+      queries.kumaStoreRequestRate(ds.uid)),
+    panels.cacheHitMissRatio(
+      'Endpoints cache performance',
+      |||
+      Cache protects ClusterLoadAssignments resources by sharing them between many goroutines which reconcile Dataplanes.
+
+      hit - request was retrieved from the cache.
+
+      hit-wait - request was retrieved from the cache after waiting for a concurrent request to fetch it from the database.
+
+      miss - request was fetched from the database
+
+      Refer to https://kuma.io/docs/latest/documentation/fine-tuning/#snapshot-generation
+|||,
+      queries.kumaClaCache(ds.uid)),
+    panels.cacheHitMissRatio(
+      'Mesh resources hash cache performance',
+      |||
+      Mesh Cache protects hashes calculated periodically for each Mesh in order to avoid the excessive generation of xDS resources.
+
+      hit - request was retrieved from the cache.
+
+      hit-wait - request was retrieved from the cache after waiting for a concurrent request to fetch it from the database.
+
+      miss - request was fetched from the database
+
+      Refer to https://kuma.io/docs/latest/documentation/fine-tuning/#snapshot-generation
+|||,
+      queries.kumaMeshCache(ds.uid)),
   ])
+  
 ]))

--- a/tools/observability/grafana/provisioning/dashboards/perf-test/panels.libsonnet
+++ b/tools/observability/grafana/provisioning/dashboards/perf-test/panels.libsonnet
@@ -8,4 +8,23 @@ local timeSeries = g.panel.timeSeries;
     + timeSeries.withDescription(desc)
     + timeSeries.queryOptions.withTargets(targets)
     + timeSeries.standardOptions.withUnit('ms'),
+
+  seconds(title, desc, targets):
+    timeSeries.new(title)
+    + timeSeries.withDescription(desc)
+    + timeSeries.queryOptions.withTargets(targets)
+    + timeSeries.standardOptions.withUnit('s'),
+
+  opsPerSec(title, desc, targets):
+    timeSeries.new(title)
+    + timeSeries.withDescription(desc)
+    + timeSeries.queryOptions.withTargets(targets)
+    + timeSeries.standardOptions.withUnit('ops'),
+
+  cacheHitMissRatio(title, desc, targets):
+    timeSeries.new(title)
+    + timeSeries.withDescription(desc)
+    + timeSeries.queryOptions.withTargets(targets)
+    + timeSeries.fieldConfig.defaults.custom.withStacking({mode: 'percent'})
+    + timeSeries.fieldConfig.defaults.custom.withFillOpacity(25)
 }

--- a/tools/observability/grafana/provisioning/dashboards/perf-test/queries.libsonnet
+++ b/tools/observability/grafana/provisioning/dashboards/perf-test/queries.libsonnet
@@ -3,9 +3,53 @@ local g = import 'g.libsonnet';
 local pq = g.query.prometheus;
 
 {
-  avgPodTimeToStart(datasource):
-    pq.new(
-      datasource,
+  avgPodTimeToStart(ds):
+    pq.new(ds,
       'avg(kube_pod_status_ready_time - kube_pod_created{namespace="kuma-test"})'
-    )
+    ),
+  
+  xdsDelivery(ds):
+    pq.new(ds,
+      'xds_delivery'
+    ) + pq.withLegendFormat('{{quantile}}'),
+    
+  xdsGeneration(ds):
+    pq.new(ds,
+      'xds_generation{result="changed"}'
+    ) + pq.withLegendFormat('{{quantile}}'),
+
+  xdsGenerationRate(ds):
+    pq.new(ds,
+      'rate(xds_generation_count[$__rate_interval])'
+    ) + pq.withLegendFormat('{{result}}'),
+    
+  kubeApiServerRequestLatency(ds, quantile):
+    pq.new(ds,
+      'histogram_quantile(%s, sum(rate(apiserver_request_duration_seconds_bucket{group="kuma.io"}[$__rate_interval])) by (le))' % quantile
+    ) + pq.withLegendFormat(quantile),
+    
+  kumaStoreRequestLatency(ds, quantile):
+    pq.new(ds,
+      'histogram_quantile(%s, sum(rate(store_bucket[$__rate_interval])) by (le))' % quantile
+    ) + pq.withLegendFormat(quantile),
+
+  kumaStoreRequestRate(ds):
+    pq.new(ds,
+      'sum by (operation) (rate(store_count[$__rate_interval]))'
+    ) + pq.withLegendFormat('{{operation}}'),
+
+  kumaApiServerLatency(ds, quantile):
+    pq.new(ds,
+      'histogram_quantile(%s, sum(rate(api_server_http_request_duration_seconds_bucket[$__rate_interval])) by (le))' % quantile
+    ) + pq.withLegendFormat(quantile),
+
+  kumaClaCache(ds):
+    pq.new(ds,
+      'sum by (result) (rate(cla_cache[$__rate_interval]))'
+    ) + pq.withLegendFormat('{{result}}'),
+
+  kumaMeshCache(ds):
+    pq.new(ds,
+      'sum by (result) (rate(mesh_cache[$__rate_interval]))'
+    ) + pq.withLegendFormat('{{result}}')
 }


### PR DESCRIPTION
Done in this PR:

* XDS config delivery (time between setting the config into snapshot up to receiving ACK/NACK)
* XDS watchdog sync (time spent on generating XDS config)
* Latency of Kube API server responses (exposed by Kubernetes)
* Latency of DB operations (exposed by Kuma)
* Kuma API server responses
* Number of XDS reconciliations
* Number of DB queries 
* CLA cache
* Mesh cache

What's missing:
* Latency of Kubernetes reconciles (Pod to Dataplane conversion, VIP generation)
* Latency of tick for all Kuma components that have tickers
* Number of Kubernetes reconciliations
* Other caches (?)