### PR TITLE
feat: add more scenarios

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/onsi/ginkgo/v2 v2.11.0
 	github.com/onsi/gomega v1.27.8
 	github.com/prometheus/client_golang v1.16.0
+	github.com/prometheus/common v0.44.0
 	k8s.io/apimachinery v0.27.3
 )
 
@@ -79,7 +80,6 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/pquerna/otp v1.2.0 // indirect
 	github.com/prometheus/client_model v0.4.0 // indirect
-	github.com/prometheus/common v0.44.0 // indirect
 	github.com/prometheus/procfs v0.10.1 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/sethvargo/go-retry v0.2.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -158,6 +158,7 @@ github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGw
 github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
+github.com/jpillora/backoff v1.0.0 h1:uvFg412JmmHBHw7iwprIxkPMI+sGQ4kzOWsMeHnm2EA=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/kelseyhightower/envconfig v1.4.0 h1:Im6hONhd3pLkfDFsbRgu68RDNkGF1r3dvMUtDTo2cv8=
@@ -210,6 +211,7 @@ github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9G
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
+github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f h1:KUppIJq7/+SVif2QVs3tOP0zanoHgBEVAwHxUSIzRqU=
 github.com/onsi/ginkgo/v2 v2.11.0 h1:WgqUCUt/lT6yXoQ8Wef0fsNn5cAuMK7+KT9UFRz2tcU=
 github.com/onsi/ginkgo/v2 v2.11.0/go.mod h1:ZhrRA5XmEE3x3rhlzamx/JJvujdZoJ2uvgI7kR0iZvM=
 github.com/onsi/gomega v1.27.8 h1:gegWiwZjBsf2DgiSbf5hpokZ98JVDMcWkUiigk6/KXc=

--- a/test/framework/cp_metrics.go
+++ b/test/framework/cp_metrics.go
@@ -1,0 +1,5 @@
+package framework
+
+func XdsDeliveryCount(promClient *PromClient) (int, error) {
+	return promClient.QueryIntValue("xds_delivery_count")
+}

--- a/test/k8s/simple_test.go
+++ b/test/k8s/simple_test.go
@@ -2,7 +2,6 @@ package k8s_test
 
 import (
 	"bytes"
-	"encoding/base64"
 	"fmt"
 	"os"
 	"strconv"
@@ -27,21 +26,6 @@ func Simple() {
 		opts := []KumaDeploymentOption{}
 
 		if license := os.Getenv("KMESH_LICENSE"); license != "" {
-			licenseEncoded := base64.StdEncoding.EncodeToString([]byte(license))
-			err := NewClusterSetup().
-				Install(Namespace(Config.KumaNamespace)).
-				Install(YamlK8s(fmt.Sprintf(`
-apiVersion: v1
-kind: Secret
-metadata:
-  name: kong-mesh-license
-  namespace: %s
-type: Opaque
-data:
-  license.json: %s
-`, Config.KumaNamespace, licenseEncoded))).
-				Setup(cluster)
-			Expect(err).ToNot(HaveOccurred())
 			opts = append(opts,
 				WithCtlOpts(map[string]string{
 					"--license-path": license,

--- a/test/k8s/simple_test.go
+++ b/test/k8s/simple_test.go
@@ -26,7 +26,7 @@ func Simple() {
 	BeforeAll(func() {
 		opts := []KumaDeploymentOption{}
 
-		if license := os.Getenv("KMESH_LICENSE_INLINE"); license != "" {
+		if license := os.Getenv("KMESH_LICENSE"); license != "" {
 			licenseEncoded := base64.StdEncoding.EncodeToString([]byte(license))
 			err := NewClusterSetup().
 				Install(Namespace(Config.KumaNamespace)).
@@ -43,10 +43,9 @@ data:
 				Setup(cluster)
 			Expect(err).ToNot(HaveOccurred())
 			opts = append(opts,
-				WithHelmOpt("controlPlane.secrets[0].Env", "KMESH_LICENSE_INLINE"),
-				WithHelmOpt("controlPlane.secrets[0].Secret", "kong-mesh-license"),
-				WithHelmOpt("controlPlane.secrets[0].Key", "license.json"),
-			)
+				WithCtlOpts(map[string]string{
+					"--license-path": license,
+				}))
 		}
 
 		err := NewClusterSetup().

--- a/test/k8s/simple_test.go
+++ b/test/k8s/simple_test.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/gruntwork-io/terratest/modules/k8s"
 	"github.com/kumahq/kuma-tools/graph"
 	"github.com/kumahq/kuma/pkg/config/core"
 	. "github.com/kumahq/kuma/test/framework"
@@ -19,6 +20,8 @@ import (
 )
 
 func Simple() {
+	numServices := 5
+
 	BeforeAll(func() {
 		opts := []KumaDeploymentOption{}
 
@@ -50,6 +53,11 @@ data:
 			Install(NamespaceWithSidecarInjection(TestNamespace)).
 			Setup(cluster)
 		Expect(err).ToNot(HaveOccurred())
+		if num := os.Getenv("TEST_NUM_SERVICES"); num != "" {
+			i, err := strconv.Atoi(num)
+			Expect(err).ToNot(HaveOccurred(), "invalid value of TEST_NUM_SERVICES")
+			numServices = i
+		}
 	})
 
 	BeforeEach(func() {
@@ -66,13 +74,12 @@ data:
 		Expect(cluster.DeleteKuma()).To(Succeed())
 	})
 
+	It("should deploy the mesh", func() {
+		// just to see stabilized stats before we go further
+		Expect(true).To(BeTrue())
+	})
+
 	It("should deploy graph", func() {
-		numServices := 5
-		if num := os.Getenv("TEST_NUM_SERVICES"); num != "" {
-			i, err := strconv.Atoi(num)
-			Expect(err).ToNot(HaveOccurred(), "invalid value of TEST_NUM_SERVICES")
-			numServices = i
-		}
 		services := graph.GenerateRandomServiceMesh(time.Now().Unix(), numServices, 50, 1, 1)
 		buffer := bytes.Buffer{}
 		err := services.ToYaml(&buffer, graph.ServiceConf{
@@ -103,5 +110,79 @@ data:
 			}()
 		}
 		wg.Wait()
+
+		//time.Sleep(10 * time.Hour)
+	})
+
+	It("should deploy mesh wide policy", func() {
+		deliveryCount, err := XdsDeliveryCount(promClient)
+		Expect(err).ToNot(HaveOccurred())
+
+		policy := `
+apiVersion: kuma.io/v1alpha1
+kind: MeshRateLimit
+metadata:
+  name: mesh-rate-limit
+  namespace: kong-mesh-system
+spec:
+  targetRef:
+    kind: Mesh
+  from:
+    - targetRef:
+        kind: Mesh
+      default:
+        local:
+          http:
+            requestRate:
+              num: 10000
+              interval: 1s
+            onRateLimit:
+              status: 429
+`
+		Expect(cluster.Install(YamlK8s(policy))).To(Succeed())
+
+		Eventually(func(g Gomega) {
+			newDeliveryCount, err := XdsDeliveryCount(promClient)
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(newDeliveryCount - deliveryCount).To(Equal(numServices))
+		}, "60s", "1s").Should(Succeed())
+	})
+
+	Context("scaling", func() {
+		scale := func(replicas int) {
+			err := k8s.RunKubectlE(
+				cluster.GetTesting(),
+				cluster.GetKubectlOptions(TestNamespace),
+				"scale", "statefulset", "srv-000", fmt.Sprintf("--replicas=%d", replicas),
+			)
+			Expect(err).ToNot(HaveOccurred())
+
+			err = cluster.Install(WaitNumPods(TestNamespace, replicas, "srv-000"))
+			Expect(err).ToNot(HaveOccurred())
+		}
+
+		It("should scale up a service", func() {
+			scale(2)
+			// there is no straightforward way to check if all Envoys received the config with the new endpoint, therefore we need to rely on stabilization sleep
+		})
+
+		It("should scale down a service", func() {
+			scale(1)
+			// there is no straightforward way to check if all Envoys received the config without the removed endpoint, therefore we need to rely on stabilization sleep
+		})
+	})
+
+	It("should distribute certs when mTLS is enabled", func() {
+		Expect(cluster.Install(MTLSMeshKubernetes("default"))).To(Succeed())
+
+		Eventually(func(g Gomega) {
+			out, err := k8s.RunKubectlAndGetOutputE(
+				cluster.GetTesting(),
+				cluster.GetKubectlOptions(),
+				"get", "meshinsights", "default", "-ojsonpath='{.spec.mTLS.issuedBackends.ca-1.total}'",
+			)
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(out).To(Equal(fmt.Sprintf("'%d'", numServices)))
+		}, "60s", "1s").Should(Succeed())
 	})
 }

--- a/test/k8s/simple_test.go
+++ b/test/k8s/simple_test.go
@@ -107,6 +107,10 @@ func Simple() {
 	})
 
 	It("should deploy mesh wide policy", func() {
+		endpoint := cluster.GetPortForward("prometheus-server").ApiServerEndpoint
+		promClient, err := NewPromClient(fmt.Sprintf("http://%s", endpoint))
+		Expect(err).ToNot(HaveOccurred())
+
 		deliveryCount, err := XdsDeliveryCount(promClient)
 		Expect(err).ToNot(HaveOccurred())
 

--- a/test/k8s/suite_test.go
+++ b/test/k8s/suite_test.go
@@ -1,7 +1,6 @@
 package k8s_test
 
 import (
-	"fmt"
 	"os"
 	"testing"
 	"time"
@@ -20,7 +19,6 @@ func TestE2E(t *testing.T) {
 }
 
 var cluster *K8sCluster
-var promClient *framework.PromClient
 var stabilizationSleep = 10 * time.Second
 
 const obsNamespace = "mesh-observability"
@@ -57,10 +55,6 @@ var _ = BeforeSuite(func() {
 	Eventually(func() error {
 		return framework.PortForwardPrometheusServer(cluster, obsNamespace)
 	}, "30s", "1s").Should(Succeed())
-
-	endpoint := cluster.GetPortForward("prometheus-server").ApiServerEndpoint
-	promClient, err = framework.NewPromClient(fmt.Sprintf("http://%s", endpoint))
-	Expect(err).ToNot(HaveOccurred())
 })
 
 var _ = AfterSuite(func() {

--- a/test/k8s/suite_test.go
+++ b/test/k8s/suite_test.go
@@ -1,6 +1,7 @@
 package k8s_test
 
 import (
+	"fmt"
 	"os"
 	"testing"
 	"time"
@@ -19,6 +20,7 @@ func TestE2E(t *testing.T) {
 }
 
 var cluster *K8sCluster
+var promClient *framework.PromClient
 var stabilizationSleep = 10 * time.Second
 
 const obsNamespace = "mesh-observability"
@@ -52,6 +54,13 @@ var _ = BeforeSuite(func() {
 	Eventually(func() error {
 		return framework.PortForwardPrometheusPushgateway(cluster, obsNamespace)
 	}, "30s", "1s").Should(Succeed())
+	Eventually(func() error {
+		return framework.PortForwardPrometheusServer(cluster, obsNamespace)
+	}, "30s", "1s").Should(Succeed())
+
+	endpoint := cluster.GetPortForward("prometheus-server").ApiServerEndpoint
+	promClient, err = framework.NewPromClient(fmt.Sprintf("http://%s", endpoint))
+	Expect(err).ToNot(HaveOccurred())
 })
 
 var _ = AfterSuite(func() {


### PR DESCRIPTION
```
• [16.749 seconds]
Simple should deploy graph
/home/mike/projects/mesh-perf/test/k8s/simple_test.go:88

  Report Entries >>
  spec.start - /home/mike/projects/mesh-perf/test/k8s/simple_test.go:67 @ 07/24/23 20:23:23.021
  duration - /home/mike/projects/mesh-perf/test/k8s/simple_test.go:123 @ 07/24/23 20:23:29.764
    6.03950113s
  spec.end - /home/mike/projects/mesh-perf/test/k8s/simple_test.go:74 @ 07/24/23 20:23:39.769
  spec.duration - /home/mike/projects/mesh-perf/test/k8s/simple_test.go:75 @ 07/24/23 20:23:39.769
    16.747684208s
  << Report Entries
------------------------------
 2023-07-24T20:23:39+02:00 retry.go:91: install yaml resource
 2023-07-24T20:23:39+02:00 logger.go:66: Running command kubectl with args [--kubeconfig /tmp/kubie-configIR9UUJ.yaml apply -f /tmp/652861821]
 2023-07-24T20:23:40+02:00 logger.go:66: meshratelimit.kuma.io/mesh-rate-limit created
• [17.276 seconds]
Simple should deploy mesh wide policy
/home/mike/projects/mesh-perf/test/k8s/simple_test.go:126

  Report Entries >>
  spec.start - /home/mike/projects/mesh-perf/test/k8s/simple_test.go:67 @ 07/24/23 20:23:39.773
  duration - /home/mike/projects/mesh-perf/test/k8s/simple_test.go:159 @ 07/24/23 20:23:47.043
    7.018134966s
  spec.end - /home/mike/projects/mesh-perf/test/k8s/simple_test.go:74 @ 07/24/23 20:23:57.045
  spec.duration - /home/mike/projects/mesh-perf/test/k8s/simple_test.go:75 @ 07/24/23 20:23:57.045
    17.272821099s
  << Report Entries
```