### PR TITLE
feat(grafana): new metrics panels

### DIFF
--- a/tools/observability/grafana/provisioning/dashboards/perf-test.json
+++ b/tools/observability/grafana/provisioning/dashboards/perf-test.json
@@ -53,7 +53,24 @@
                   "type": "prometheus",
                   "uid": "Prometheus"
                },
-               "expr": "avg(kube_pod_status_ready_time - kube_pod_created{namespace=\"kuma-test\"})"
+               "expr": "quantile(0.50, kube_pod_status_ready_time - kube_pod_created{namespace=\"kuma-test\"})",
+               "legendFormat": "0.50"
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "Prometheus"
+               },
+               "expr": "quantile(0.90, kube_pod_status_ready_time - kube_pod_created{namespace=\"kuma-test\"})",
+               "legendFormat": "0.90"
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "Prometheus"
+               },
+               "expr": "quantile(0.99, kube_pod_status_ready_time - kube_pod_created{namespace=\"kuma-test\"})",
+               "legendFormat": "0.99"
             }
          ],
          "title": "Pod Startup Time",
@@ -107,14 +124,92 @@
          "type": "timeseries"
       },
       {
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "description": "Length of time per reconcile for pod controller",
+         "fieldConfig": {
+            "defaults": {
+               "unit": "s"
+            }
+         },
+         "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 16,
+            "y": 1
+         },
+         "id": 4,
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "Prometheus"
+               },
+               "expr": "histogram_quantile(0.50, sum(rate(controller_runtime_reconcile_time_seconds_bucket{controller=\"pod\"}[$__rate_interval])) by (le))",
+               "legendFormat": "0.50"
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "Prometheus"
+               },
+               "expr": "histogram_quantile(0.90, sum(rate(controller_runtime_reconcile_time_seconds_bucket{controller=\"pod\"}[$__rate_interval])) by (le))",
+               "legendFormat": "0.90"
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "Prometheus"
+               },
+               "expr": "histogram_quantile(0.99, sum(rate(controller_runtime_reconcile_time_seconds_bucket{controller=\"pod\"}[$__rate_interval])) by (le))",
+               "legendFormat": "0.99"
+            }
+         ],
+         "title": "Latency of Pod to Dataplane conversion",
+         "type": "timeseries"
+      },
+      {
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "description": "",
+         "fieldConfig": {
+            "defaults": {
+               "unit": "ops"
+            }
+         },
+         "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 0,
+            "y": 10
+         },
+         "id": 5,
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "Prometheus"
+               },
+               "expr": "sum by (result) (rate(controller_runtime_reconcile_total{controller=\"pod\"}[$__rate_interval]))",
+               "legendFormat": "{{result}}"
+            }
+         ],
+         "title": "Number of Pod reconciliation ",
+         "type": "timeseries"
+      },
+      {
          "collapsed": false,
          "gridPos": {
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 9
+            "y": 18
          },
-         "id": 4,
+         "id": 6,
          "panels": [ ],
          "title": "Kuma Control Plane",
          "type": "row"
@@ -134,9 +229,9 @@
             "h": 8,
             "w": 8,
             "x": 0,
-            "y": 10
+            "y": 19
          },
-         "id": 5,
+         "id": 7,
          "targets": [
             {
                "datasource": {
@@ -165,9 +260,9 @@
             "h": 8,
             "w": 8,
             "x": 8,
-            "y": 10
+            "y": 19
          },
-         "id": 6,
+         "id": 8,
          "targets": [
             {
                "datasource": {
@@ -196,9 +291,9 @@
             "h": 8,
             "w": 8,
             "x": 16,
-            "y": 10
+            "y": 19
          },
-         "id": 7,
+         "id": 9,
          "targets": [
             {
                "datasource": {
@@ -243,9 +338,9 @@
             "h": 8,
             "w": 8,
             "x": 0,
-            "y": 19
+            "y": 28
          },
-         "id": 8,
+         "id": 10,
          "targets": [
             {
                "datasource": {
@@ -290,9 +385,9 @@
             "h": 8,
             "w": 8,
             "x": 8,
-            "y": 19
+            "y": 28
          },
-         "id": 9,
+         "id": 11,
          "targets": [
             {
                "datasource": {
@@ -321,9 +416,9 @@
             "h": 8,
             "w": 8,
             "x": 16,
-            "y": 19
+            "y": 28
          },
-         "id": 10,
+         "id": 12,
          "targets": [
             {
                "datasource": {
@@ -357,9 +452,9 @@
             "h": 8,
             "w": 8,
             "x": 0,
-            "y": 28
+            "y": 37
          },
-         "id": 11,
+         "id": 13,
          "targets": [
             {
                "datasource": {
@@ -393,9 +488,9 @@
             "h": 8,
             "w": 8,
             "x": 8,
-            "y": 28
+            "y": 37
          },
-         "id": 12,
+         "id": 14,
          "targets": [
             {
                "datasource": {

--- a/tools/observability/grafana/provisioning/dashboards/perf-test.json
+++ b/tools/observability/grafana/provisioning/dashboards/perf-test.json
@@ -202,6 +202,42 @@
          "type": "timeseries"
       },
       {
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "description": "Number of cache operations for Kubernetes authentication on XDS connection",
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 25,
+                  "stacking": {
+                     "mode": "percent"
+                  }
+               }
+            }
+         },
+         "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 8,
+            "y": 10
+         },
+         "id": 6,
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "Prometheus"
+               },
+               "expr": "sum by (result) (rate(kube_auth_cache[$__rate_interval]))",
+               "legendFormat": "{{result}}"
+            }
+         ],
+         "title": "Kube Auth cache performance",
+         "type": "timeseries"
+      },
+      {
          "collapsed": false,
          "gridPos": {
             "h": 1,
@@ -209,7 +245,7 @@
             "x": 0,
             "y": 18
          },
-         "id": 6,
+         "id": 7,
          "panels": [ ],
          "title": "Kuma Control Plane",
          "type": "row"
@@ -231,7 +267,7 @@
             "x": 0,
             "y": 19
          },
-         "id": 7,
+         "id": 8,
          "targets": [
             {
                "datasource": {
@@ -262,7 +298,7 @@
             "x": 8,
             "y": 19
          },
-         "id": 8,
+         "id": 9,
          "targets": [
             {
                "datasource": {
@@ -293,7 +329,7 @@
             "x": 16,
             "y": 19
          },
-         "id": 9,
+         "id": 10,
          "targets": [
             {
                "datasource": {
@@ -340,7 +376,7 @@
             "x": 0,
             "y": 28
          },
-         "id": 10,
+         "id": 11,
          "targets": [
             {
                "datasource": {
@@ -387,7 +423,7 @@
             "x": 8,
             "y": 28
          },
-         "id": 11,
+         "id": 12,
          "targets": [
             {
                "datasource": {
@@ -418,7 +454,7 @@
             "x": 16,
             "y": 28
          },
-         "id": 12,
+         "id": 13,
          "targets": [
             {
                "datasource": {
@@ -454,7 +490,7 @@
             "x": 0,
             "y": 37
          },
-         "id": 13,
+         "id": 14,
          "targets": [
             {
                "datasource": {
@@ -490,7 +526,7 @@
             "x": 8,
             "y": 37
          },
-         "id": 14,
+         "id": 15,
          "targets": [
             {
                "datasource": {

--- a/tools/observability/grafana/provisioning/dashboards/perf-test.json
+++ b/tools/observability/grafana/provisioning/dashboards/perf-test.json
@@ -198,7 +198,7 @@
                "legendFormat": "{{result}}"
             }
          ],
-         "title": "Number of Pod reconciliation ",
+         "title": "Number of Pod reconciliation",
          "type": "timeseries"
       },
       {

--- a/tools/observability/grafana/provisioning/dashboards/perf-test/main.libsonnet
+++ b/tools/observability/grafana/provisioning/dashboards/perf-test/main.libsonnet
@@ -51,6 +51,10 @@ g.dashboard.new('Perf Test')
       'Number of Pod reconciliation ',
       '',
       queries.controllerRuntimeReconcileRate(ds.uid)),
+    panels.cacheHitMissRatio(
+      'Kube Auth cache performance',
+      'Number of cache operations for Kubernetes authentication on XDS connection',
+      queries.kubeAuthCache(ds.uid)),
   ]),
   
   row.new('Kuma Control Plane')

--- a/tools/observability/grafana/provisioning/dashboards/perf-test/main.libsonnet
+++ b/tools/observability/grafana/provisioning/dashboards/perf-test/main.libsonnet
@@ -48,7 +48,7 @@ g.dashboard.new('Perf Test')
         queries.controllerRuntimeReconcileLatency(ds.uid, "0.99"),
       ]),
     panels.opsPerSec(
-      'Number of Pod reconciliation ',
+      'Number of Pod reconciliation',
       '',
       queries.controllerRuntimeReconcileRate(ds.uid)),
     panels.cacheHitMissRatio(

--- a/tools/observability/grafana/provisioning/dashboards/perf-test/main.libsonnet
+++ b/tools/observability/grafana/provisioning/dashboards/perf-test/main.libsonnet
@@ -26,15 +26,31 @@ g.dashboard.new('Perf Test')
     panels.milliseconds(
       'Pod Startup Time', 
       'Average time between Pod creation and readiness', 
-      queries.avgPodTimeToStart(ds.uid)),
+      [
+        queries.podTimeToStart(ds.uid, "0.50"),
+        queries.podTimeToStart(ds.uid, "0.90"),
+        queries.podTimeToStart(ds.uid, "0.99"),
+      ]),
     panels.seconds(
-      'Latency of Kube API server responses', 
-      'The latency between a request sent from a client and a response returned by kube-apiserver', 
+      'Latency of Kube API server responses',
+      'The latency between a request sent from a client and a response returned by kube-apiserver',
       [
         queries.kubeApiServerRequestLatency(ds.uid, "0.50"),
         queries.kubeApiServerRequestLatency(ds.uid, "0.90"),
         queries.kubeApiServerRequestLatency(ds.uid, "0.99"),
       ]),
+    panels.seconds(
+      'Latency of Pod to Dataplane conversion',
+      'Length of time per reconcile for pod controller',
+      [
+        queries.controllerRuntimeReconcileLatency(ds.uid, "0.50"),
+        queries.controllerRuntimeReconcileLatency(ds.uid, "0.90"),
+        queries.controllerRuntimeReconcileLatency(ds.uid, "0.99"),
+      ]),
+    panels.opsPerSec(
+      'Number of Pod reconciliation ',
+      '',
+      queries.controllerRuntimeReconcileRate(ds.uid)),
   ]),
   
   row.new('Kuma Control Plane')

--- a/tools/observability/grafana/provisioning/dashboards/perf-test/queries.libsonnet
+++ b/tools/observability/grafana/provisioning/dashboards/perf-test/queries.libsonnet
@@ -53,6 +53,11 @@ local pq = g.query.prometheus;
       'sum by (result) (rate(mesh_cache[$__rate_interval]))'
     ) + pq.withLegendFormat('{{result}}'),
 
+  kubeAuthCache(ds):
+    pq.new(ds,
+      'sum by (result) (rate(kube_auth_cache[$__rate_interval]))'
+    ) + pq.withLegendFormat('{{result}}'),
+
   controllerRuntimeReconcileLatency(ds, quantile):
     pq.new(ds,
       'histogram_quantile(%s, sum(rate(controller_runtime_reconcile_time_seconds_bucket{controller="pod"}[$__rate_interval])) by (le))' % quantile


### PR DESCRIPTION
This PR adds:
* Latency of Pod to Dataplane conversion
* Number of Pod reconciliation
* Kube Auth cache performance

Updates:
* "Pod Startup Time" to have quantiles instead of avg