### PR TITLE
feat(mk): create report of spec runs along with parameters

### DIFF
--- a/mk/run.mk
+++ b/mk/run.mk
@@ -5,6 +5,8 @@ E2E_ENV_VARS += KUMA_K8S_TYPE=k3d
 E2E_ENV_VARS += E2E_CONFIG_FILE="$(TOP)/test/cfg.yaml"
 E2E_ENV_VARS += KUMACTLBIN="$(KUMACTLBIN)"
 E2E_ENV_VARS += MESH_VERSION=$(MESH_VERSION)
+E2E_ENV_VARS += PERF_TEST_NUM_SERVICES=$${PERF_TEST_NUM_SERVICES:=5}
+E2E_ENV_VARS += PERF_TEST_STABILIZATION_SLEEP=$${PERF_TEST_STABILIZATION_SLEEP:=10s}
 
 .PHONY:
 fetch-mesh:
@@ -12,8 +14,6 @@ fetch-mesh:
 	[ -f $(KUMACTLBIN) ] || (cd build && curl -L https://docs.konghq.com/mesh/installer.sh | VERSION=$(MESH_VERSION) sh -)
 
 .PHONY: run
-run: export PERF_TEST_NUM_SERVICES ?= 5
-run: export PERF_TEST_STABILIZATION_SLEEP ?= 10s
 run: fetch-mesh
 	$(E2E_ENV_VARS) $(GINKGO) --json-report=raw-report.json ./test/...
-	jq '{Parameters: env | with_entries(select(.key | startswith("PERF_TEST"))), Suites: .}' raw-report.json > report.json
+	$(E2E_ENV_VARS) jq '{Parameters: env | with_entries(select(.key | startswith("PERF_TEST"))), Suites: .}' raw-report.json > report.json

--- a/mk/run.mk
+++ b/mk/run.mk
@@ -12,5 +12,8 @@ fetch-mesh:
 	[ -f $(KUMACTLBIN) ] || (cd build && curl -L https://docs.konghq.com/mesh/installer.sh | VERSION=$(MESH_VERSION) sh -)
 
 .PHONY: run
+run: export PERF_TEST_NUM_SERVICES ?= 5
+run: export PERF_TEST_STABILIZATION_SLEEP ?= 10s
 run: fetch-mesh
-	$(E2E_ENV_VARS) $(GINKGO) ./test/...
+	$(E2E_ENV_VARS) $(GINKGO) --json-report=raw-report.json ./test/...
+	jq '{Parameters: env | with_entries(select(.key | startswith("PERF_TEST"))), Suites: .}' raw-report.json > report.json

--- a/test/k8s/simple_test.go
+++ b/test/k8s/simple_test.go
@@ -19,7 +19,7 @@ import (
 )
 
 func Simple() {
-	numServices := 5
+	var numServices int
 	var start time.Time
 
 	BeforeAll(func() {
@@ -37,11 +37,10 @@ func Simple() {
 			Install(NamespaceWithSidecarInjection(TestNamespace)).
 			Setup(cluster)
 		Expect(err).ToNot(HaveOccurred())
-		if num := os.Getenv("TEST_NUM_SERVICES"); num != "" {
-			i, err := strconv.Atoi(num)
-			Expect(err).ToNot(HaveOccurred(), "invalid value of TEST_NUM_SERVICES")
-			numServices = i
-		}
+		num := requireVar("PERF_TEST_NUM_SERVICES")
+		i, err := strconv.Atoi(num)
+		Expect(err).ToNot(HaveOccurred(), "invalid value of PERF_TEST_NUM_SERVICES")
+		numServices = i
 	})
 
 	BeforeEach(func() {


### PR DESCRIPTION
https://github.com/Kong/mesh-perf/issues/49

After runs we have a `report.json` like:

```
{
  "Parameters": {
    "PERF_TEST_STABILIZATION_SLEEP": "10s",
    "PERF_TEST_NUM_SERVICES": "5"
  },
  "Suites": [
    {
      "SuitePath": "/home/mike/projects/mesh-perf/test/k8s",
      "SuiteDescription": "E2E Kubernetes Suite",
      ...
      "SpecReports": [
        {
          "LeafNodeText": "should deploy the mesh",
          ...
          "ReportEntries": [
            {
              "Name": "spec.duration",
              "Value": {
                "AsJSON": "10002420063",
                "Representation": "10.002420063s"
              }
            }
       ...
```