### PR TITLE
fix(test): add retries when copy snapshot, wait on correct num instances

### DIFF
--- a/test/framework/prometheus.go
+++ b/test/framework/prometheus.go
@@ -69,7 +69,7 @@ func SavePrometheusSnapshot(cluster framework.Cluster, namespace string, hostPat
 	err = k8s.RunKubectlE(
 		cluster.GetTesting(),
 		cluster.GetKubectlOptions(),
-		"cp", src, dest, "-c", "prometheus-server",
+		"cp", src, dest, "-c", "prometheus-server", "--retries", "10",
 	)
 	if err != nil {
 		return err

--- a/test/k8s/simple_test.go
+++ b/test/k8s/simple_test.go
@@ -100,7 +100,7 @@ func Simple() {
 				defer wg.Done()
 				err := NewClusterSetup().
 					Install(WaitService(TestNamespace, name)).
-					Install(WaitNumPods(TestNamespace, 1, name)).
+					Install(WaitNumPods(TestNamespace, instancesPerService, name)).
 					Install(WaitPodsAvailable(TestNamespace, name)).
 					Setup(cluster)
 				Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
If the Prometheus snapshot is slightly bigger then `kubectl cp` fails to download the file with the following error:
```
tar: removing leading '/' from member names
Dropping out copy after 0 retries
error: unexpected EOF
```

Seems like a known issue of kubectl https://github.com/kubernetes/kubectl/issues/1425, adding `--retries` fixes the problem.