### PR TITLE
fix(test): support to run multiple instances per service at bigger scale

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 TOP = $(shell pwd)
 
 # Possible to use Kong Mesh version in the following format 0.0.0-preview.v964544ae9
-PERF_TEST_MESH_VERSION ?= 0.0.0-preview.vaa5a34907
+PERF_TEST_MESH_VERSION ?= 0.0.0-preview.v4798d5f9f
 
 include mk/dev.mk
 include mk/check.mk

--- a/test/k8s/simple_test.go
+++ b/test/k8s/simple_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 	"strconv"
-	"sync"
 	"time"
 
 	"github.com/gruntwork-io/terratest/modules/k8s"
@@ -27,7 +26,14 @@ func Simple() {
 	var start time.Time
 
 	BeforeAll(func() {
-		opts := []KumaDeploymentOption{}
+		opts := []KumaDeploymentOption{
+			WithCtlOpts(map[string]string{
+				"--set": "" +
+					"kuma.controlPlane.resources.requests.cpu=1," +
+					"kuma.controlPlane.resources.requests.memory=2Gi," +
+					"kuma.controlPlane.resources.limits.memory=8Gi",
+			}),
+		}
 
 		if license := os.Getenv("KMESH_LICENSE"); license != "" {
 			opts = append(opts,
@@ -92,25 +98,11 @@ func Simple() {
 
 		Expect(cluster.Install(YamlK8s(buffer.String()))).To(Succeed())
 
-		wg := sync.WaitGroup{}
-		wg.Add(numServices)
-
-		start := time.Now()
-
-		for i := 0; i < numServices; i++ {
-			name := fmt.Sprintf("srv-%03d", i)
-			go func() {
-				defer GinkgoRecover()
-				defer wg.Done()
-				err := NewClusterSetup().
-					Install(WaitService(TestNamespace, name)).
-					Install(WaitNumPods(TestNamespace, instancesPerService, name)).
-					Install(WaitPodsAvailable(TestNamespace, name)).
-					Setup(cluster)
-				Expect(err).ToNot(HaveOccurred())
-			}()
-		}
-		wg.Wait()
+		Eventually(func() error {
+			expectedNumOfPods := numServices*instancesPerService + 1
+			return k8s.WaitUntilNumPodsCreatedE(cluster.GetTesting(), cluster.GetKubectlOptions(TestNamespace),
+				metav1.ListOptions{}, expectedNumOfPods, 1, 0)
+		}, "10m", "3s").Should(Succeed())
 
 		AddReportEntry("duration", time.Now().Sub(start))
 	})
@@ -192,16 +184,16 @@ spec:
 		}
 
 		It("should scale up a service", func() {
-			scale(2)
+			scale(instancesPerService + 1)
 		})
 
 		It("should scale down a service", func() {
-			scale(1)
+			scale(instancesPerService)
 		})
 	})
 
 	It("should distribute certs when mTLS is enabled", func() {
-		expectedCerts := numServices + 1
+		expectedCerts := numServices*instancesPerService + 1
 		Expect(cluster.Install(MTLSMeshKubernetes("default"))).To(Succeed())
 
 		start := time.Now()


### PR DESCRIPTION
* update KM version
* increase CP resources
* optimize waiting for a number of pods to be deployed
* use `instancesPerService` in assertions