### PR TITLE
fix(test): increase timeout on waiting for xds messages to propagate

### DIFF
--- a/test/k8s/simple_test.go
+++ b/test/k8s/simple_test.go
@@ -178,7 +178,7 @@ spec:
 			newDeliveryCount, err := framework.XdsDeliveryCount(promClient)
 			g.Expect(err).ToNot(HaveOccurred())
 			g.Expect(newDeliveryCount - deliveryCount).To(Equal(numServices * instancesPerService))
-		}, "60s", "1s").Should(Succeed())
+		}, "2m", "1s").Should(Succeed())
 		AddReportEntry("policy_propagation_duration", time.Now().Sub(propagationStart))
 	})
 


### PR DESCRIPTION
Apparently, 60s timeout is not enough. Test constantly fails, the last 3 runs:
* https://github.com/Kong/mesh-perf/actions/runs/6006322432/job/16290654415
* https://github.com/Kong/mesh-perf/actions/runs/5994016318/job/16255096719
* https://github.com/Kong/mesh-perf/actions/runs/5970239579/job/16197508252
