### PR TITLE
When report duration use Milliseconds instead of a String representation

### DIFF
--- a/jsonnetfile.lock.json
+++ b/jsonnetfile.lock.json
@@ -28,7 +28,7 @@
           "subdir": "gen/grafonnet-latest"
         }
       },
-      "version": "502afadc4158af9d4cacd7b9b6dd06b3bce2fb41",
+      "version": "1757b16ae293868dc745359ace45f2c3010ac95f",
       "sum": "sVzVlSLbxPkAurwO19YERigLMmRfVsViMcWC0gkTTqU="
     },
     {
@@ -38,7 +38,7 @@
           "subdir": "gen/grafonnet-v10.0.0"
         }
       },
-      "version": "502afadc4158af9d4cacd7b9b6dd06b3bce2fb41",
+      "version": "1757b16ae293868dc745359ace45f2c3010ac95f",
       "sum": "al5VJMRi6u2Bkutif6MUA/CnAHUhT9CttFPiNXKhUXc="
     },
     {
@@ -48,8 +48,8 @@
           "subdir": "grafonnet-base"
         }
       },
-      "version": "502afadc4158af9d4cacd7b9b6dd06b3bce2fb41",
-      "sum": "oenOrTd/4NPbygAl+RG9v3wdUBey9CMsLmBKJanOwMc="
+      "version": "1757b16ae293868dc745359ace45f2c3010ac95f",
+      "sum": "m85c4oyQB5BYqUh1fEBMz5YLDDPj8aHrO0BA7E81Pxg="
     },
     {
       "source": {

--- a/test/k8s/simple_test.go
+++ b/test/k8s/simple_test.go
@@ -105,7 +105,7 @@ func Simple() {
 
 		Expect(framework.ReportSpecEnd(cluster)).To(Succeed())
 		end := time.Now()
-		AddReportEntry("duration", end.Sub(start).Abs())
+		AddReportEntry("duration", end.Sub(start).Milliseconds())
 	})
 
 	E2EAfterAll(func() {
@@ -179,7 +179,7 @@ spec:
 			g.Expect(err).ToNot(HaveOccurred())
 			g.Expect(newDeliveryCount - deliveryCount).To(Equal(numServices * instancesPerService))
 		}, "60s", "1s").Should(Succeed())
-		AddReportEntry("policy_propagation_duration", time.Now().Sub(propagationStart))
+		AddReportEntry("policy_propagation_duration", time.Now().Sub(propagationStart).Milliseconds())
 	})
 
 	Context("scaling", func() {
@@ -225,7 +225,7 @@ spec:
 				g.Expect(err).ToNot(HaveOccurred())
 				g.Expect(membership.Stats[0].Value).To(BeNumerically("==", replicas))
 			}, "60s", "1s").Should(Succeed())
-			AddReportEntry("endpoint_propagation_duration", time.Now().Sub(propagationStart))
+			AddReportEntry("endpoint_propagation_duration", time.Now().Sub(propagationStart).Milliseconds())
 		}
 
 		It("should scale up a service", func() {
@@ -251,6 +251,6 @@ spec:
 			g.Expect(err).ToNot(HaveOccurred())
 			g.Expect(out).To(Equal(fmt.Sprintf("'%d'", expectedCerts)))
 		}, "60s", "1s").Should(Succeed())
-		AddReportEntry("certs_propagation_duration", time.Now().Sub(propagationStart))
+		AddReportEntry("certs_propagation_duration", time.Now().Sub(propagationStart).Milliseconds())
 	})
 }

--- a/test/k8s/simple_test.go
+++ b/test/k8s/simple_test.go
@@ -105,7 +105,7 @@ func Simple() {
 
 		Expect(framework.ReportSpecEnd(cluster)).To(Succeed())
 		end := time.Now()
-		AddReportEntry("duration", end.Sub(start))
+		AddReportEntry("duration", end.Sub(start).Abs())
 	})
 
 	E2EAfterAll(func() {


### PR DESCRIPTION
Instead of `"duration": "5s"` we'll get `"duration": 5000`