### PR TITLE
fix(mk): stop jsonnet-bundler update every 'make check'

### DIFF
--- a/mk/generate.mk
+++ b/mk/generate.mk
@@ -4,7 +4,7 @@ JSONNET_BUNDLER_CACHE_DIR=build/jsonnet
 dashboards = $(foreach dir,$(shell find $(DASHBOARDS_DIR) -maxdepth 1 -mindepth 1 -type d | sort),$(notdir $(dir)))
 
 $(JSONNET_BUNDLER_CACHE_DIR):
-	$(JSONNET_BUNDLER) update --jsonnetpkg-home=$(JSONNET_BUNDLER_CACHE_DIR)
+	$(JSONNET_BUNDLER) install --jsonnetpkg-home=$(JSONNET_BUNDLER_CACHE_DIR)
 
 generate-grafana-%:
 	$(JSONNET) -J $(JSONNET_BUNDLER_CACHE_DIR) $(DASHBOARDS_DIR)/$*/main.libsonnet -o $(DASHBOARDS_DIR)/$*.json


### PR DESCRIPTION
Initially, I've put `jb update` by mistake, we don't want to update jsonnet dependencies on every `make check`.