### PR TITLE
ci(gha): set necessary permissions for project-lifecycle workflow

### DIFF
--- a/.github/workflows/lifecycle.yml
+++ b/.github/workflows/lifecycle.yml
@@ -9,8 +9,15 @@ on:
       - opened
       - labeled
 
+permissions: {}
+
 jobs:
   lifecycle:
     uses: kumahq/.github/.github/workflows/wfc_lifecycle.yml@main
+    permissions:
+      actions: read
+      contents: write
+      issues: write
+      pull-requests: write
     with:
       filesToIgnore: "CODE_OF_CONDUCT.md,LICENSE,SECURITY.md,CODEOWNERS,GOVERNANCE.md,CONTRIBUTING.md"


### PR DESCRIPTION
`project-lifecycle` workflow is currently failing because of the change in the default `GITHUB_TOKEN` permissions for this repo (i.e. https://github.com/Kong/mesh-perf/actions/runs/12742163229/job/35509866366) and this PR fixes is