### PR TITLE
chore(renovate): remove unnecessary preset version pins

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "github>Kong/public-shared-renovate:backend#1.4.0",
-    "github>kumahq/kuma//.renovate/go-control-plane"
+    "Kong/public-shared-renovate:backend",
+    "kumahq/kuma//.renovate/go-control-plane"
   ],
   "enabledManagers": [
     "docker-compose",


### PR DESCRIPTION
- Removed version pins from presets, as pinning doesn't improve security here
- Even if tags were overwritten, the impact is minimal (only weird updates)
- Cleaned up redundant 'github>' prefixes