### PR TITLE
fix(prom): prometheus service port was always 80 not sure how it worked before

### DIFF
--- a/test/framework/prometheus.go
+++ b/test/framework/prometheus.go
@@ -23,7 +23,7 @@ import (
 type PatchKind string
 
 const (
-	PortPrometheusServer           = 9090
+	PortPrometheusServer           = 80
 	NamePrometheusServer           = "prometheus-server"
 	NameGrafana                    = "grafana"
 	KindDeployment       PatchKind = "deployment"


### PR DESCRIPTION
Motivation: https://github.com/Kong/mesh-perf/actions/runs/17288692247/job/49070841755#step:8:1347

Run from this branch: https://github.com/Kong/mesh-perf/actions/runs/17290120047

```
• [FAILED] [156.979 seconds]
Simple [AfterEach] should deploy the mesh
  [AfterEach] /home/runner/work/mesh-perf/mesh-perf/test/k8s/simple_test.go:109
  [It] /home/runner/work/mesh-perf/mesh-perf/test/k8s/simple_test.go:141

  [FAILED] Unexpected error:
      <*errors.withStack | 0xc0010bb3f8>: 
      port forwarding for 42187:9090 failed: Target port 9090 not found in service prometheus-server definition.
      {
          error: <*errors.withMessage | 0xc0013c1200>{
              cause: <*errors.errorString | 0xc000a55e30>{
                  s: "Target port 9090 not found in service prometheus-server definition.",
              },
              msg: "port forwarding for 42187:9090 failed",
          },
          stack: [0x2c2b9de, 0x2c5581a, 0x2c55451, 0x2d8d386, 0x19746fe, 0x198a21b, 0x4845a1],
      }
  occurred
  In [AfterEach] at: /home/runner/work/mesh-perf/mesh-perf/test/k8s/simple_test.go:111 @ 08/28/25 07:38:36.672
```