### PR TITLE
ci(renovate): pin shared presets and switch go-control-plane source

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,14 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "Kong/public-shared-renovate:backend",
-    "kumahq/kuma//.renovate/go-control-plane"
-  ],
-  "enabledManagers": [
-    "docker-compose",
-    "github-actions",
-    "gomod",
-    "jsonnet-bundler",
-    "terraform"
+    "Kong/public-shared-renovate:backend#1.12.0",
+    "Kong/public-shared-renovate//modules/kuma/go-control-plane#1.12.0"
   ]
 }


### PR DESCRIPTION
## Motivation

The Renovate configuration in mesh-perf was broken because it still referenced the old `kumahq/kuma//.renovate/go-control-plane` preset. That preset has been removed and moved to `Kong/public-shared-renovate`. As a result, Renovate could not load the configuration. Additionally, the config was still using unpinned shared presets and explicitly listed enabled managers, which are no longer needed. This PR fixes the configuration and ensures consistency across runs.

## Implementation information

### Use versioned shared presets

- Replaced `Kong/public-shared-renovate:backend` with `Kong/public-shared-renovate:backend#1.12.0`  
- Replaced `kumahq/kuma//.renovate/go-control-plane` with `Kong/public-shared-renovate//modules/kuma/go-control-plane#1.12.0`  

### Remove explicit enabledManagers

- Dropped the manual `enabledManagers` list and now rely on Renovate defaults  

## Result

- Renovate configuration loads successfully again  
- go-control-plane updates are now handled by the central shared preset in `Kong/public-shared-renovate`  
- Presets are pinned to a version (`#1.12.0`), making Renovate runs deterministic and reproducible  
- Configuration is simpler and aligned with current Renovate best practices  

## Supporting documentation

- Fixes: https://github.com/Kong/mesh-perf/issues/402